### PR TITLE
Fix N+1 queries, dead code, and stale docs from DB layer PR review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Database Configuration (optional - defaults to SQLite)
+# DATABASE_URL=sqlite:///./activities.db
+# For PostgreSQL: DATABASE_URL=postgresql://user:password@localhost/dbname
+# For MySQL: DATABASE_URL=mysql+pymysql://user:password@localhost/dbname
+
+# SQL Query Logging (for debugging)
+# SQL_ECHO=false

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -41,11 +41,19 @@ The database file `activities.db` will be created in the `src/` directory.
 ```
 
 **PostgreSQL**
+
+Install a PostgreSQL DBAPI driver first (for example, `psycopg`):
 ```bash
-export DATABASE_URL="postgresql://user:password@localhost/school_activities"
+pip install psycopg
+export DATABASE_URL="postgresql+psycopg://user:password@localhost/school_activities"
 ```
 
 **MySQL**
+
+Install the PyMySQL driver first:
+```bash
+pip install pymysql
+```
 ```bash
 export DATABASE_URL="mysql+pymysql://user:password@localhost/school_activities"
 ```
@@ -67,7 +75,7 @@ export SQL_ECHO=true
 - **Migrations**: Use Alembic for schema versioning in production
 - **Transactions**: Add savepoint/rollback handling for complex operations
 - **Indexing**: Add database indexes on frequently queried fields
-- **Constraints**: Add database-level uniqueness constraints for enrollments
+- **Constraints**: Add additional database constraints and validation rules as needed beyond the existing enrollment uniqueness constraint
 
 ## API Compatibility
 

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -1,0 +1,79 @@
+# Database Setup and Migration Guide
+
+## Overview
+This application now uses SQLModel/SQLAlchemy with SQLite for persistent data storage. Data survives server restarts.
+
+## Architecture
+
+### Database Layer (`src/database.py`)
+- Configures SQLAlchemy engine
+- Provides session factory via FastAPI dependency injection
+- Supports SQLite (default) and PostgreSQL/MySQL via `DATABASE_URL` environment variable
+- Automatic table creation on startup
+
+### Data Models (`src/models.py`)
+- **Student**: `email` (unique), `created_at`
+- **Activity**: `name` (unique), `description`, `schedule`, `max_participants`, timestamps
+- **Enrollment**: Many-to-many relationship between Student and Activity, prevents duplicates
+
+### API Integration (`src/app.py`)
+- Database session injected into endpoints via FastAPI `Depends()`
+- Startup event calls `create_db_and_tables()` and `seed_database()`
+- Default activities seeded on first startup with sample participants
+- All existing API endpoints remain backward-compatible
+
+## Local Development
+
+### Setup
+```bash
+pip install -r requirements.txt
+cd src
+uvicorn app:app --reload
+```
+
+The database file `activities.db` will be created in the `src/` directory.
+
+### Database Configuration
+
+**SQLite (default)**
+```bash
+# No configuration needed - uses ./activities.db
+```
+
+**PostgreSQL**
+```bash
+export DATABASE_URL="postgresql://user:password@localhost/school_activities"
+```
+
+**MySQL**
+```bash
+export DATABASE_URL="mysql+pymysql://user:password@localhost/school_activities"
+```
+
+Enable SQL query logging:
+```bash
+export SQL_ECHO=true
+```
+
+## Testing the Persistence
+
+1. Sign up a student for an activity via `/activities/{name}/signup`
+2. Stop the server (Ctrl+C)
+3. Restart the server
+4. Query `/activities` - the signup should still exist
+
+## Future Enhancements
+
+- **Migrations**: Use Alembic for schema versioning in production
+- **Transactions**: Add savepoint/rollback handling for complex operations
+- **Indexing**: Add database indexes on frequently queried fields
+- **Constraints**: Add database-level uniqueness constraints for enrollments
+
+## API Compatibility
+
+All existing endpoints work as before:
+- `GET /activities` - returns activities with participant lists
+- `POST /activities/{name}/signup?email=...` - creates enrollment
+- `DELETE /activities/{name}/unregister?email=...` - removes enrollment
+
+Response format is unchanged for frontend compatibility.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+sqlmodel
+sqlalchemy
+alembic

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,16 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from sqlmodel import Session, select
+from datetime import datetime
+
+from database import create_db_and_tables, get_session, engine
+from models import Activity, Student, Enrollment
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +24,123 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
+
+# Default seed data for initial activities
+DEFAULT_ACTIVITIES = [
+    {
+        "name": "Chess Club",
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
         "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
     },
-    "Programming Class": {
+    {
+        "name": "Programming Class",
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
-    "Gym Class": {
+    {
+        "name": "Gym Class",
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
-    "Soccer Team": {
+    {
+        "name": "Soccer Team",
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
         "participants": ["liam@mergington.edu", "noah@mergington.edu"]
     },
-    "Basketball Team": {
+    {
+        "name": "Basketball Team",
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
         "participants": ["ava@mergington.edu", "mia@mergington.edu"]
     },
-    "Art Club": {
+    {
+        "name": "Art Club",
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
         "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
     },
-    "Drama Club": {
+    {
+        "name": "Drama Club",
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
         "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
     },
-    "Math Club": {
+    {
+        "name": "Math Club",
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
         "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
     },
-    "Debate Team": {
+    {
+        "name": "Debate Team",
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
-}
+]
+
+
+def seed_database():
+    """Seed the database with default activities and participants"""
+    session = Session(engine)
+    try:
+        # Check if database is already seeded
+        statement = select(Activity)
+        existing = session.exec(statement).first()
+        if existing is not None:
+            return
+        
+        # Seed activities
+        for activity_data in DEFAULT_ACTIVITIES:
+            activity = Activity(
+                name=activity_data["name"],
+                description=activity_data["description"],
+                schedule=activity_data["schedule"],
+                max_participants=activity_data["max_participants"]
+            )
+            session.add(activity)
+            session.flush()
+            
+            # Add participants
+            for email in activity_data["participants"]:
+                # Create or get student
+                statement = select(Student).where(Student.email == email)
+                student = session.exec(statement).first()
+                if not student:
+                    student = Student(email=email)
+                    session.add(student)
+                    session.flush()
+                
+                # Create enrollment
+                enrollment = Enrollment(
+                    student_id=student.id,
+                    activity_id=activity.id
+                )
+                session.add(enrollment)
+        
+        session.commit()
+    finally:
+        session.close()
+
+
+@app.on_event("startup")
+def on_startup():
+    """Initialize database on startup"""
+    create_db_and_tables()
+    seed_database()
 
 
 @app.get("/")
@@ -84,49 +149,110 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(session: Session = Depends(get_session)):
+    """Get all activities with their current participants"""
+    statement = select(Activity)
+    activities_list = session.exec(statement).all()
+    
+    # Convert to dictionary format for backward compatibility with frontend
+    result = {}
+    for activity in activities_list:
+        result[activity.name] = {
+            "description": activity.description,
+            "schedule": activity.schedule,
+            "max_participants": activity.max_participants,
+            "participants": [enrollment.student.email for enrollment in activity.enrollments]
+        }
+    return result
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, session: Session = Depends(get_session)):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    # Get activity by name
+    statement = select(Activity).where(Activity.name == activity_name)
+    activity = session.exec(statement).first()
+    
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
+    
+    # Check if student is already enrolled
+    statement = select(Enrollment).where(
+        (Enrollment.activity_id == activity.id) &
+        (Enrollment.student_id == select(Student.id).where(Student.email == email))
+    )
+    
+    # Get or create student
+    statement = select(Student).where(Student.email == email)
+    student = session.exec(statement).first()
+    if not student:
+        student = Student(email=email)
+        session.add(student)
+        session.flush()
+    
+    # Check for existing enrollment
+    statement = select(Enrollment).where(
+        (Enrollment.activity_id == activity.id) &
+        (Enrollment.student_id == student.id)
+    )
+    existing_enrollment = session.exec(statement).first()
+    
+    if existing_enrollment:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
         )
-
-    # Add student
-    activity["participants"].append(email)
+    
+    # Check if activity is at capacity
+    if activity.participant_count >= activity.max_participants:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is at maximum capacity"
+        )
+    
+    # Create enrollment
+    enrollment = Enrollment(student_id=student.id, activity_id=activity.id)
+    session.add(enrollment)
+    session.commit()
+    
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, session: Session = Depends(get_session)):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    # Get activity by name
+    statement = select(Activity).where(Activity.name == activity_name)
+    activity = session.exec(statement).first()
+    
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
+    
+    # Get student
+    statement = select(Student).where(Student.email == email)
+    student = session.exec(statement).first()
+    
+    if not student:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
-
-    # Remove student
-    activity["participants"].remove(email)
+    
+    # Get enrollment
+    statement = select(Enrollment).where(
+        (Enrollment.activity_id == activity.id) &
+        (Enrollment.student_id == student.id)
+    )
+    enrollment = session.exec(statement).first()
+    
+    if not enrollment:
+        raise HTTPException(
+            status_code=400,
+            detail="Student is not signed up for this activity"
+        )
+    
+    # Remove enrollment
+    session.delete(enrollment)
+    session.commit()
+    
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from sqlalchemy import func
+from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
 from database import create_db_and_tables, get_session, engine
@@ -150,7 +152,9 @@ def root():
 @app.get("/activities")
 def get_activities(session: Session = Depends(get_session)):
     """Get all activities with their current participants"""
-    statement = select(Activity)
+    statement = select(Activity).options(
+        selectinload(Activity.enrollments).selectinload(Enrollment.student)
+    )
     activities_list = session.exec(statement).all()
     
     # Convert to dictionary format for backward compatibility with frontend
@@ -175,12 +179,6 @@ def signup_for_activity(activity_name: str, email: str, session: Session = Depen
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
     
-    # Check if student is already enrolled
-    statement = select(Enrollment).where(
-        (Enrollment.activity_id == activity.id) &
-        (Enrollment.student_id == select(Student.id).where(Student.email == email))
-    )
-    
     # Get or create student
     statement = select(Student).where(Student.email == email)
     student = session.exec(statement).first()
@@ -203,7 +201,9 @@ def signup_for_activity(activity_name: str, email: str, session: Session = Depen
         )
     
     # Check if activity is at capacity
-    if activity.participant_count >= activity.max_participants:
+    count_statement = select(func.count(Enrollment.id)).where(Enrollment.activity_id == activity.id)
+    participant_count = session.exec(count_statement).one()
+    if participant_count >= activity.max_participants:
         raise HTTPException(
             status_code=400,
             detail="Activity is at maximum capacity"

--- a/src/app.py
+++ b/src/app.py
@@ -11,7 +11,6 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 from sqlmodel import Session, select
-from datetime import datetime
 
 from database import create_db_and_tables, get_session, engine
 from models import Activity, Student, Enrollment

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,32 @@
+"""Database configuration and session management"""
+
+import os
+from sqlalchemy.orm import Session
+from sqlmodel import SQLModel, create_engine, Session as SQLModelSession
+
+# Database configuration - defaults to SQLite for local development
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./activities.db")
+
+# Create engine with different settings based on database type
+if DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(
+        DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        echo=os.getenv("SQL_ECHO", "false").lower() == "true"
+    )
+else:
+    engine = create_engine(
+        DATABASE_URL,
+        echo=os.getenv("SQL_ECHO", "false").lower() == "true"
+    )
+
+
+def create_db_and_tables():
+    """Create database tables"""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    """Get database session for dependency injection"""
+    with SQLModelSession(engine) as session:
+        yield session

--- a/src/database.py
+++ b/src/database.py
@@ -1,7 +1,6 @@
 """Database configuration and session management"""
 
 import os
-from sqlalchemy.orm import Session
 from sqlmodel import SQLModel, create_engine, Session as SQLModelSession
 
 # Database configuration - defaults to SQLite for local development

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,51 @@
+"""SQLModel database models"""
+
+from typing import Optional, List
+from datetime import datetime
+from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy import UniqueConstraint
+
+
+class Student(SQLModel, table=True):
+    """Student model"""
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(unique=True, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    
+    # Relationships
+    enrollments: List["Enrollment"] = Relationship(back_populates="student")
+
+
+class Activity(SQLModel, table=True):
+    """Activity model"""
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(unique=True, index=True)
+    description: str
+    schedule: str
+    max_participants: int = Field(default=20)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    
+    # Relationships
+    enrollments: List["Enrollment"] = Relationship(back_populates="activity")
+    
+    @property
+    def participant_count(self) -> int:
+        """Get number of enrolled participants"""
+        return len(self.enrollments)
+
+
+class Enrollment(SQLModel, table=True):
+    """Enrollment model - represents a student signed up for an activity"""
+    id: Optional[int] = Field(default=None, primary_key=True)
+    student_id: int = Field(foreign_key="student.id")
+    activity_id: int = Field(foreign_key="activity.id")
+    enrolled_at: datetime = Field(default_factory=datetime.utcnow)
+    
+    # Relationships
+    student: Student = Relationship(back_populates="enrollments")
+    activity: Activity = Relationship(back_populates="enrollments")
+    
+    __table_args__ = (
+        UniqueConstraint("student_id", "activity_id", name="uq_student_activity"),
+    )


### PR DESCRIPTION
Addresses all feedback from the code review on the persistent data layer PR.

## Code fixes

- **Dead code removed**: `signup_for_activity` had a `select(Enrollment)` block using an invalid subquery (`student_id == select(Student.id)...`) that was immediately overwritten — deleted entirely
- **N+1 eliminated**: `get_activities` now uses `selectinload` to fetch enrollments+students in 2 queries instead of per-row lazy loads:
  ```python
  select(Activity).options(
      selectinload(Activity.enrollments).selectinload(Enrollment.student)
  )
  ```
- **COUNT instead of collection load**: capacity check in `signup_for_activity` replaced `len(activity.enrollments)` with `SELECT COUNT(*)`:
  ```python
  count_statement = select(func.count(Enrollment.id)).where(Enrollment.activity_id == activity.id)
  participant_count = session.exec(count_statement).one()
  ```
- **Unused import**: removed `from sqlalchemy.orm import Session` in `database.py` (shadowed by `SQLModelSession`)

## Docs fixes (`DATABASE_SETUP.md`)

- PostgreSQL and MySQL sections now include required driver install steps (`psycopg`, `pymysql`)
- Removed incorrect future-enhancement bullet about "adding uniqueness constraints for enrollments" — constraint already exists on `(student_id, activity_id)`